### PR TITLE
[27기 김성현] detial 페이지 -> 백통신 부분

### DIFF
--- a/src/components/Nav/Nav.js
+++ b/src/components/Nav/Nav.js
@@ -9,7 +9,9 @@ import { kakaoLogin, logingOut } from '../../api/KakaoApi';
 const Nav = () => {
   const navigate = useNavigate();
   const [isWideSearchBar, setIsWideSearchBar] = useState(false);
-  const [loggedIn, setLoggedIn] = useState(false);
+  const [loggedIn, setLoggedIn] = useState(
+    !!sessionStorage.getItem('Authorization')
+  );
   const [profileOpened, setProfileOpened] = useState(false);
   const profile = useRef();
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,13 @@
-const BASELINE_JONGHO = 'http://10.58.6.17:8000';
+// const BASELINE_JONGHO = 'http://10.58.6.17:8000';
 const BASELINE_JUHO = 'http://10.58.7.3:8000';
-const BASELINE_JINSUNG = 'http://10.58.0.42:8000';
+// const BASELINE_JUNGHO = 'http://10.58.0.105:8000';
+const BASELINE_JINSUNG = 'http://10.58.5.23:8000';
 
 export const API = {
-  carts: `${BASELINE_JUHO}/carts`,
-  login: `${BASELINE_JUHO}/users/kakao/signin`,
+  carts: `${BASELINE_JINSUNG}/carts`,
+  login: `${BASELINE_JINSUNG}/users/kakao/signin`,
   book: `${BASELINE_JINSUNG}/books`,
   review: `${BASELINE_JINSUNG}/books/review`,
-  books: `${BASELINE_JUHO}/books/all`,
+  books: `${BASELINE_JINSUNG}/books/all`,
+  orders: `${BASELINE_JINSUNG}/orders`,
 };

--- a/src/pages/Detail/Detail.js
+++ b/src/pages/Detail/Detail.js
@@ -13,25 +13,28 @@ function Detail() {
   const Authorization = sessionStorage.getItem('Authorization');
 
   const getReviews = useCallback(() => {
-    // TODO 백엔드 통신
-    // fetch('/data/reviews.json')
-    fetch(`${API.review}/${bookId}`)
+    fetch(`${API.review}?book_id=${bookId}`)
       .then(res => res.json())
       .then(res => {
-        setAboutReviews(res.result);
+        if (!!res.result) {
+          setAboutReviews(res.result[0]);
+          return;
+        }
+
+        switch (res.message) {
+          case 'DOES_NOT_EXIST':
+            alert('에러입니다');
+            break;
+          default:
+            break;
+        }
       })
       .catch(e => {
         console.error(e);
       });
-    // TODO 에러처리
-    // 성공시 다시 변경하기
-    // }, [Authorization, bookId]);
   }, [bookId]);
 
   useEffect(() => {
-    // TODO 백엔드 통신 부분
-    // fetch(`/data/book${bookId}.json`)
-
     fetch(`${API.book}/${bookId}`, {
       headers: {
         ...(Authorization && { Authorization: Authorization }),

--- a/src/pages/Detail/DetailReviews/Reviews/Reviews.js
+++ b/src/pages/Detail/DetailReviews/Reviews/Reviews.js
@@ -5,7 +5,7 @@ import Review from '../Review/Review';
 function Reviews({ reviews, deleteReview }) {
   return (
     <ReviewsWrapper>
-      {!reviews.length ? (
+      {!reviews || !reviews.length ? (
         <ReviewWrapper>첫번째 리뷰어가 되어주세요 :)</ReviewWrapper>
       ) : (
         reviews.map(review => (


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
상세 페이지 백통신 해야하는 부분 구현
- 상세페이지 내용
- 장바구니 추가
- 구매하기
- 댓글 추가
- 댓글 삭제 
- 로그인 초기 설정 부분 변경 -> 계속 로그인 버튼으로 보이는 문제 해결

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 책 미리 보기, 보기는 파일이 아닌 url 을 백엔드로부터 받아 보여 줄 수 있도록 했습니다.

- 상세페이지에서 데이터를 처음에 받아올 때, 로그인 상태에 따라 백엔드에 보내는 부분을 보냈습니다.

- 댓글 추가하고 삭제할 때 성공 시, 댓글을 다시 GET 하여 댓글 부분을 업데이트해서 보여주도록 했습니다.

- 댓글 추가는 책을 구한 사용자만 쓸 수 있도록 했습니다.

- 책 구매시 구매 성공을 하면 
-> 다시 book의 상태를 백으로 부터 받아 구매 상태를 바꾸지 않고 
-> 프론트에서 book 의 상태를 변경해서 purchase : true 일 때의 상세 페이지 를 보여주도록 했습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- Restful API 에서 delete 메소드는 성공 시 백엔드에서 status 204를 보내는데, 204의 경우 responese 를 보낼 수 없기 때문에, 성공 여부를 response.message 가 아닌 status 또는 statusText로 확인해서 처리해야 함을 알게 되었습니다.
(204에서 백엔드에서 json 으로 감아서 response 를 보내도 프론트에서 json input 문제가 뜹니다.)

- headers에 key 부분 자체도 없애는 방법을 알게 되었습니다.
```javascript
    fetch(`${API.book}/${bookId}`, {
      headers: {
        ...(Authorization && { Authorization: Authorization }),
      },
    })
```

<br />

## :: 기타 질문 및 특이 사항

